### PR TITLE
ci: trigger Flux image scans after push

### DIFF
--- a/.github/workflows/docker-image.yml
+++ b/.github/workflows/docker-image.yml
@@ -24,6 +24,8 @@ on:
         required: false
       GITLAB_REGISTRY_PASSWORD:
         required: false
+      FLUX_IMAGE_WEBHOOK_URLS:
+        required: false
 
 env:
   REGISTRY: registry.gitlab.com
@@ -35,6 +37,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      id-token: write
 
     steps:
       - name: Checkout
@@ -100,3 +103,37 @@ jobs:
           while IFS= read -r tag; do
             docker push "${tag}"
           done <<< "${TAGS}"
+
+      - name: Trigger Flux image scans
+        if: github.event_name != 'pull_request' && github.ref == 'refs/heads/main'
+        env:
+          IMAGE: ${{ inputs.image }}
+          WEBHOOK_URLS: ${{ secrets.FLUX_IMAGE_WEBHOOK_URLS }}
+        run: |
+          set -euo pipefail
+
+          if [[ -z "${WEBHOOK_URLS}" ]]; then
+            echo "No Flux image webhook URLs configured; skipping."
+            exit 0
+          fi
+
+          oidc_token="$(
+            curl -fsSL \
+              -H "Authorization: bearer ${ACTIONS_ID_TOKEN_REQUEST_TOKEN}" \
+              "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=notification-controller" \
+              | jq -r '.value'
+          )"
+          payload="$(jq -cn --arg image "${IMAGE}" '{images: [$image]}')"
+
+          while IFS= read -r webhook_url; do
+            if [[ -z "${webhook_url}" ]]; then
+              continue
+            fi
+
+            curl -fsS \
+              -X POST \
+              -H "Authorization: Bearer ${oidc_token}" \
+              -H "Content-Type: application/json" \
+              --data "${payload}" \
+              "${webhook_url}"
+          done <<< "${WEBHOOK_URLS}"


### PR DESCRIPTION
## Summary
- request a GitHub Actions OIDC token after publishing an image on main
- POST the pushed image name to configured Flux image webhook URLs
- keep the step optional when FLUX_IMAGE_WEBHOOK_URLS is not configured

## Verification
- actionlint