### PR TITLE
Add custom Paperless image

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -23,6 +23,15 @@
     },
     {
       "matchFileNames": [
+        "paperless/**"
+      ],
+      "labels": [
+        "paperless"
+      ],
+      "additionalBranchPrefix": "paperless-"
+    },
+    {
+      "matchFileNames": [
         "teamcity-agent/**"
       ],
       "labels": [

--- a/.github/workflows/paperless.yml
+++ b/.github/workflows/paperless.yml
@@ -1,0 +1,29 @@
+name: Paperless Image
+
+on:
+  pull_request:
+    paths:
+      - paperless/**
+      - .github/workflows/paperless.yml
+      - .github/workflows/docker-image.yml
+  push:
+    branches:
+      - main
+    paths:
+      - paperless/**
+      - .github/workflows/paperless.yml
+      - .github/workflows/docker-image.yml
+  workflow_dispatch:
+
+jobs:
+  docker-image:
+    permissions:
+      contents: read
+      id-token: write
+    uses: ./.github/workflows/docker-image.yml
+    with:
+      image: paperless
+      context: paperless
+      version_offset: 0
+      push_latest: true
+    secrets: inherit

--- a/paperless/Dockerfile
+++ b/paperless/Dockerfile
@@ -1,0 +1,18 @@
+FROM ghcr.io/paperless-ngx/paperless-ngx:2.20.15@sha256:6c86cad803970ea782683a8e80e7403444c5bf3cf70de63b4d3c8e87500db92f
+
+USER root
+
+ARG DEBIAN_FRONTEND=noninteractive
+
+RUN set -eux; \
+    apt-get update; \
+    apt-get upgrade --yes --quiet; \
+    apt-get clean --yes; \
+    rm -rf /var/lib/apt/lists/* /var/cache/apt/archives/*
+
+COPY constraints.txt /usr/local/share/paperless-overrides/constraints.txt
+
+RUN set -eux; \
+    python3 -m pip install --upgrade --requirement /usr/local/share/paperless-overrides/constraints.txt; \
+    python3 -m pip check; \
+    rm -rf /root/.cache/pip

--- a/paperless/constraints.txt
+++ b/paperless/constraints.txt
@@ -1,0 +1,13 @@
+Django==5.2.13
+Brotli==1.2.0
+PyJWT==2.13.0
+cryptography==49.0.0
+fido2==2.2.1
+granian==2.7.9
+lxml==6.1.1
+msgpack==1.2.1
+nltk==3.10.0
+pdfminer.six==20260107
+pillow==12.3.0
+tornado==6.5.7
+urllib3==2.7.0


### PR DESCRIPTION
## Summary
- add a custom Paperless image derived from the official pinned image
- refresh Debian packages during the image build
- apply pinned Python security upgrades from a Renovate-readable constraints file
- add a dedicated Paperless workflow that uses the existing reusable Docker image workflow

## Verification
- `actionlint`
- `docker build -t paperless-custom:local -f paperless/Dockerfile paperless`
- `trivy image --ignore-unfixed --severity HIGH,CRITICAL paperless-custom:local`: `high_critical_findings=0`